### PR TITLE
Handle unknown fields ("_") in PCD files

### DIFF
--- a/pcd-rs/src/utils.rs
+++ b/pcd-rs/src/utils.rs
@@ -78,14 +78,20 @@ pub fn load_meta<R: BufRead>(reader: &mut R, line_count: &mut usize) -> Result<P
         let mut name_set = HashSet::new();
         let mut field_names: Vec<String> = vec![];
 
-        for tk in tokens[1..].iter() {
-            let field = tk;
-            if name_set.contains(field) {
+        for (idx, tk) in tokens[1..].iter().enumerate() {
+            let mut field = tk.clone();
+            // If this field is just an underscore, it was meant to be skipped. Label it as
+            // unknown_field_{idx}
+            if field == String::from("_") {
+                field = format!("unknown_field_{idx}");
+            }
+
+            if name_set.contains(&field.clone()) {
                 let desc = format!("field name {:?} is specified more than once", field);
                 return Err(Error::new_parse_error(*line_count, &desc).into());
             }
 
-            name_set.insert(field);
+            name_set.insert(field.clone());
             field_names.push(field.to_owned());
         }
 


### PR DESCRIPTION
Some PCD files, such as ones that are output by PCL-ROS (http://wiki.ros.org/pcl_ros), can use "_" as an unlabeled field name, such as

```
VERSION 0.7
FIELDS x y z _ intensity t reflectivity ring ambient _ range _
```

In this case, the PCD reader will (correctly, though uselessly) report a "duplicate field". This MR fixes this by converting those underscores to an "unknown_field" string that is then propagated to the user. This means data is not lost, and the user can still access the data.

Example from SO:
https://stackoverflow.com/questions/56983991/how-to-unpack-convert-binary-data-in-a-file-into-readable-values