### PR TITLE
Reconcile binary_compressed uncompressed_size with header-derived size before prealloc

### DIFF
--- a/pcd-rs/src/reader.rs
+++ b/pcd-rs/src/reader.rs
@@ -132,6 +132,36 @@ where
                 // Empty compressed data
                 Some(Cursor::new(Vec::new()))
             } else {
+                // The uncompressed payload of a binary_compressed section is the
+                // column-major point array whose length is fully determined by the
+                // ASCII header: sum(field.byte_size * field.count) * num_points. Treat
+                // the body's `uncompressed_size` as a verifiable value, not a primary
+                // allocation driver: reject on mismatch with the header-derived
+                // expected size before preallocating. Mirrors PCL's `readBodyBinary`,
+                // which sizes `cloud.data` from `nr_points * point_step` and flags any
+                // divergence as corruption. Prevents an attacker-controlled `u32` from
+                // driving a multi-GiB allocation regardless of the declared point count.
+                let num_points = meta.num_points as usize;
+                let field_byte_sizes: Vec<usize> = meta
+                    .field_defs
+                    .iter()
+                    .map(|f| f.kind.byte_size() * f.count as usize)
+                    .collect();
+                let record_size: usize = field_byte_sizes.iter().sum();
+                let expected_uncompressed =
+                    record_size.checked_mul(num_points).ok_or_else(|| {
+                        Error::new_parse_error(
+                        0,
+                        "binary_compressed size overflow: record_size * num_points exceeds usize",
+                    )
+                    })?;
+                if uncompressed_size as usize != expected_uncompressed {
+                    return Err(Error::new_parse_error(
+                        0,
+                        "binary_compressed uncompressed_size does not match header-derived size",
+                    ));
+                }
+
                 // Read compressed data
                 let mut compressed_data = vec![0u8; compressed_size as usize];
                 reader.read_exact(&mut compressed_data)?;
@@ -140,18 +170,9 @@ where
                 let col_major = lzf::decompress(&compressed_data, uncompressed_size as usize)?;
 
                 // Transpose from column-major to row-major so read_chunk works
-                let num_points = meta.num_points as usize;
                 if num_points == 0 {
                     Some(Cursor::new(col_major))
                 } else {
-                    // Calculate per-field byte sizes and record size
-                    let field_byte_sizes: Vec<usize> = meta
-                        .field_defs
-                        .iter()
-                        .map(|f| f.kind.byte_size() * f.count as usize)
-                        .collect();
-                    let record_size: usize = field_byte_sizes.iter().sum();
-
                     let mut row_major = vec![0u8; col_major.len()];
 
                     // column_start[f] is the byte offset where field f's column begins

--- a/pcd-rs/tests/test_compressed_size_reconcile.rs
+++ b/pcd-rs/tests/test_compressed_size_reconcile.rs
@@ -1,0 +1,221 @@
+//! Regression tests for binary_compressed uncompressed_size reconciliation.
+//!
+//! The `binary_compressed` data section carries two attacker-controlled `u32`
+//! fields (`compressed_size`, `uncompressed_size`) read from the binary body.
+//! The reader must treat `uncompressed_size` as a verifiable value, not a
+//! primary allocation driver: the expected uncompressed length is fully
+//! determined by the ASCII header (`sum(field.byte_size * field.count) *
+//! num_points`). A divergence is corruption (or an attack) and must be rejected
+//! *before* preallocating — otherwise an attacker can drive a multi-GiB
+//! allocation from a handful of header bytes regardless of the declared point
+//! count (untrusted-count preallocation DoS).
+//!
+//! These tests use small, modest `uncompressed_size` values that mismatch the
+//! header-derived expected size (e.g. 1 KiB vs an expected 4 bytes), proving
+//! the reconciliation fires on the Err path *before* any large allocation.
+//! They do NOT allocate the declared size.
+
+use pcd_rs::{DataKind, DynReader, DynRecord, DynWriter, Field, Schema, ValueKind, WriterInit};
+use std::io::Cursor;
+
+/// Minimal PCD v0.7 `DATA binary_compressed` header for a single-field
+/// (x: f32), single-point cloud. The header-derived expected uncompressed size
+/// is `record_size(4) * num_points(1) = 4 bytes`.
+fn build_header() -> Vec<u8> {
+    let h = b"VERSION 0.7\n\
+FIELDS x\n\
+SIZE 4\n\
+TYPE F\n\
+COUNT 1\n\
+WIDTH 1\n\
+HEIGHT 1\n\
+POINTS 1\n\
+DATA binary_compressed\n";
+    h.to_vec()
+}
+
+/// Append the two body size u32s (little-endian) followed by `body` bytes.
+fn build_blob(compressed_size: u32, uncompressed_size: u32, body: &[u8]) -> Vec<u8> {
+    let mut buf = build_header();
+    buf.extend_from_slice(&compressed_size.to_le_bytes());
+    buf.extend_from_slice(&uncompressed_size.to_le_bytes());
+    buf.extend_from_slice(body);
+    buf
+}
+
+/// Build an LZF-compressed stream that decompresses to *exactly* `n` bytes,
+/// every byte written (self-referencing back-references with offset=1 starting
+/// from a single literal). Used to construct a body whose `uncompressed_size`
+/// matches the actual decompressed length so that, on the unfixed reader, the
+/// LZF decoder succeeds and `from_bytes` returns `Ok` (the RED: an attacker
+/// `u32` is trusted as the allocation magnitude and accepted despite the header
+/// saying the record is 4 bytes).
+fn build_lzf_exact(n: usize) -> Vec<u8> {
+    assert!(n >= 1, "build_lzf_exact expects n >= 1");
+    let mut out: Vec<u8> = Vec::with_capacity(n / 64 + 16);
+    // 1 literal byte seeds the back-reference source.
+    out.push(0u8); // literal run of length 1
+    out.push(b'A');
+    let mut remaining = n - 1;
+    // Full 264-byte back-references (long form: len = 7 + 255 + 2 = 264).
+    while remaining > 264 {
+        out.push(0xe0);
+        out.push(255);
+        out.push(0); // offset = 0 + 0 + 1 = 1 (self-ref)
+        remaining -= 264;
+    }
+    // Final remainder in [0, 264].
+    match remaining {
+        0 => {}
+        1 => {
+            // A back-reference has minimum length 2; emit a 1-byte literal instead.
+            out.push(0u8); // literal run of length 1
+            out.push(b'A');
+        }
+        r if r >= 9 => {
+            // long form: len = 7 + extra + 2 = 9 + extra
+            out.push(0xe0);
+            out.push((r - 9) as u8);
+            out.push(0);
+        }
+        r => {
+            // short form: len = (ctrl >> 5) + 2; ctrl = (r - 2) << 5
+            out.push(((r - 2) << 5) as u8);
+            out.push(0); // offset_low (offset = 0 + 0 + 1 = 1)
+        }
+    }
+    out
+}
+
+#[test]
+fn test_uncompressed_size_mismatch_small_rejected() {
+    // Header says POINTS 1 / FIELDS x / SIZE 4 -> expected uncompressed = 4
+    // bytes, but the body declares uncompressed_size = 1 KiB. This must Err
+    // (not Ok, and crucially not allocate 1 KiB from the untrusted u32).
+    let body = vec![0u8; 8];
+    let blob = build_blob(body.len() as u32, 1024, &body);
+    let res = DynReader::from_bytes(&blob);
+    assert!(
+        res.is_err(),
+        "uncompressed_size mismatch (1024 != header-derived 4) must be rejected before prealloc"
+    );
+}
+
+#[test]
+fn test_uncompressed_size_huge_virtual_rejected() {
+    // Probe A shape: compressed_size=0, uncompressed_size=256 MiB. Before the
+    // fix this executed `vec![0u8; 256 MiB]` inside `lzf::decompress` and only
+    // errored afterwards (the attacker u32 appeared verbatim in the error
+    // string). After the fix the reconciliation rejects it before any
+    // allocation. We use 256 MiB as the declared size but never materialize it.
+    let blob = build_blob(0, 256 * 1024 * 1024, &[]);
+    let res = DynReader::from_bytes(&blob);
+    assert!(
+        res.is_err(),
+        "uncompressed_size=256 MiB on a 4-byte record must be rejected before prealloc"
+    );
+    // The error must be the reconciliation error, not the post-alloc LZF error
+    // that embeds the attacker u32 verbatim.
+    let err = match res {
+        Ok(_) => panic!("expected Err, got Ok"),
+        Err(e) => format!("{}", e),
+    };
+    assert!(
+        !err.contains("268435456"),
+        "must not reach lzf::decompress (which would embed the attacker u32); got: {err}"
+    );
+}
+
+#[test]
+fn test_uncompressed_size_physical_amplification_rejected() {
+    // Probe B shape (scaled down to a modest 1 KiB so the test never makes a
+    // large allocation): a tiny LZF stream of self-referencing back-references
+    // that decompresses to *exactly* the declared `uncompressed_size` (1024).
+    // On the unfixed reader the LZF decoder succeeds, `col_major`/`row_major`
+    // are allocated from the attacker `u32`, and `from_bytes` returns **Ok**
+    // despite the header saying the record is 4 bytes (the RED:
+    // Ok-when-it-should-Err). After the fix the reconciliation rejects before
+    // any allocation. (The scanner harness proves the same path at 64 MiB ->
+    // ~68 MiB RSS -> Ok on pristine HEAD; this is the modest in-tree guard.)
+    let declared = 1024usize;
+    let lzf = build_lzf_exact(declared);
+    let blob = build_blob(lzf.len() as u32, declared as u32, &lzf);
+    let res = DynReader::from_bytes(&blob);
+    assert!(
+        res.is_err(),
+        "uncompressed_size=1024 on a 4-byte record must be rejected before prealloc \
+         (on unfixed HEAD this returned Ok)"
+    );
+}
+
+#[test]
+fn test_compressed_size_only_zero_with_nonzero_uncompressed_rejected() {
+    // compressed_size=0 but uncompressed_size != expected. The empty shortcut
+    // only triggers when *both* are zero; otherwise the reconciliation must
+    // reject. (compressed_size=0 means read_exact reads nothing, but the
+    // uncompressed_size check still fires first.)
+    let blob = build_blob(0, 8, &[]);
+    let res = DynReader::from_bytes(&blob);
+    assert!(
+        res.is_err(),
+        "uncompressed_size=8 (!= expected 4) with compressed_size=0 must be rejected"
+    );
+}
+
+#[test]
+fn test_empty_compressed_cloud_still_loads() {
+    // An empty compressed cloud (POINTS 0) is written with both size fields 0;
+    // the empty shortcut must still return Ok with zero points.
+    let h = b"VERSION 0.7\n\
+FIELDS x\n\
+SIZE 4\n\
+TYPE F\n\
+COUNT 1\n\
+WIDTH 0\n\
+HEIGHT 1\n\
+POINTS 0\n\
+DATA binary_compressed\n";
+    let mut blob = h.to_vec();
+    blob.extend_from_slice(&0u32.to_le_bytes()); // compressed_size
+    blob.extend_from_slice(&0u32.to_le_bytes()); // uncompressed_size
+    let reader = DynReader::from_bytes(&blob).expect("empty compressed cloud must load");
+    let meta = reader.meta();
+    assert_eq!(meta.num_points, 0);
+}
+
+#[test]
+fn test_valid_small_compressed_cloud_still_loads() {
+    // A well-formed binary_compressed cloud (header-derived expected == body
+    // uncompressed_size) must still parse Ok and yield the correct point. Build
+    // it with the public Writer API into an in-memory buffer, then read back.
+    let schema = Schema::from_iter([("x", ValueKind::F32, 1)]);
+
+    let mut buf = Vec::new();
+    let cursor = Cursor::new(&mut buf);
+
+    {
+        let mut writer: DynWriter<_> = WriterInit {
+            width: 1,
+            height: 1,
+            viewpoint: Default::default(),
+            data_kind: DataKind::BinaryCompressed,
+            schema: Some(schema),
+            version: None,
+        }
+        .build_from_writer(cursor)
+        .expect("build writer");
+
+        writer
+            .push(&DynRecord(vec![Field::F32(vec![1.0])]))
+            .expect("push");
+        writer.finish().expect("finish");
+    }
+
+    let reader = DynReader::from_bytes(&buf).expect("valid compressed cloud must load");
+    let points: Vec<DynRecord> = reader.collect::<Result<_, _>>().expect("collect");
+    assert_eq!(points.len(), 1);
+    match &points[0].0[0] {
+        Field::F32(v) => assert_eq!(v[0], 1.0),
+        _ => panic!("Expected F32"),
+    }
+}


### PR DESCRIPTION
## Problem

In the PCD `DATA binary_compressed` (LZF) reader, `Reader::from_reader` reads two attacker-controlled `u32`s (`compressed_size`, `uncompressed_size`) from the binary body and preallocates `vec![0u8; <u32> as usize]` from them **before** any cross-check against the remaining stream length or the header-derived expected size -- even though it computes `record_size * num_points` (the expected uncompressed size) a few lines later and ignores it.

This is an untrusted-count preallocation DoS:

- **Physical amplification:** a ~745 KiB LZF stream of self-referencing back-references + header `POINTS 1 / FIELDS x / SIZE 4` (expected uncompressed = 4 bytes) + body `uncompressed_size = 64 MiB` -> `DynReader::from_bytes` returns **Ok** with peak RSS ~67 MiB (**~93x input->RSS amplification**; ~176x input->allocation across both buffers). Ceiling = 4 GiB per u32.
- **Speculative reserve:** a 100-byte input with `uncompressed_size = 256 MiB` executes `vec![0u8; 256 MiB]` (the attacker u32 appears verbatim in the error string).

## Evidence / oracle

Internal asymmetry: the header-derived expected size is computed in the same function but never reconciled with the body u32. Reference: PCL `pcl/io/src/pcd_io.cpp` `readBodyBinary` allocates `cloud.data` from the header (`nr_points * point_step`) and treats the body `uncompressed_size` as a corruption checksum (`PCL_WARN` on mismatch; `return -1` if actual decompressed size != stored value). PCL rejects both probes; pcd-rs allocates the attacker u32 verbatim and returns Ok.

## Fix

Hoist `num_points`/`field_byte_sizes`/`record_size` above the preallocations and reconcile the body `uncompressed_size` against the header-derived `record_size.checked_mul(num_points)` (overflow -> Err) before `compressed_data`/`lzf::decompress`/`row_major` can allocate; reject on mismatch via `Error::new_parse_error`. Mirrors PCL (size from header; treat `uncompressed_size` as a checksum). LZF decoder not refactored.

## Tests

`cargo test --all-features`: all suites pass, 0 failed (6 new `test_compressed_size_reconcile` tests with modest 1 KiB probes -- no large allocations). `cargo +nightly fmt --check` clean. `cargo clippy`: 0 warnings, 0 errors. Pre-fix: 2 tests fail (physical returns Ok-when-it-should-Err; virtual reaches lzf::decompress and embeds the attacker u32); post-fix: pass. Harness re-run on fixed code: both probes Err before allocating; **0 amplification** (was ~93x).

Out of scope: `compressed_size` has no cheap reliable remaining-stream-length bound for the file-backed path; the existing `read_exact` backstop remains.